### PR TITLE
Add min batch size and command-line option disabling it

### DIFF
--- a/src/embedded/Listen.py
+++ b/src/embedded/Listen.py
@@ -47,12 +47,14 @@ def main():
     else:
         predictor = TwoStageModelPredictor.TwoStageModelPredictor(args.model_path, batch_size=args.batch_size, jump=jump)
 
+    min_batch_size = 1 if args.allow_smaller_batches else args.batch_size
     data_coordinator = DataCoordinator.DataCoordinator(
         args.predicted_intervals_output_path, args.blackout_intervals_output_path, jump=jump,
         prediction_threshold=args.prediction_threshold,
         spectrogram_capture_dir=args.spectrogram_capture_dir,
         max_captured_disk_usage=args.captured_disk_usage_limit,
         time_delta_per_time_step=args.hop/args.sampling_freq,
+        min_batch_size=min_batch_size,
         override_buffer_size=convert_mb_to_num_elements(args.spectrogram_buffer_size_mb,
                                                         MODEL_INPUT_FREQUENCY_BINS * SpectrogramBuffer.BYTES_PER_ELEMENT))
 

--- a/src/embedded/args.py
+++ b/src/embedded/args.py
@@ -29,6 +29,11 @@ def get_embedded_listening_args():
     parser.add_argument('--batch-size', type=int, default=4,
                         help="How many spectrogram frames the model should be run on in parallel. More powerful " +
                              "hardware can benefit from larger values, but it may cause slowdown past a certain point.")
+    parser.add_argument('--allow-smaller-batches', action='store_true',
+                        help="Specify this to allow the predictor to process data as soon as there is enough for a model" +
+                             "prediction instead of waiting until there is a full batch ready. This may decrease power " +
+                             "efficiency but it will also decrease memory pressure on the machine. It will also allow " +
+                             "predictions to be made sooner, which could be important if some real-time response is desired.")
     parser.add_argument('--jump', type=int, default=64,
                         help="The offset in time-steps of adjacent predicted spectrogram frames. Must be an even " +
                              "divisor of the model input's time dimension.")


### PR DESCRIPTION
The data comes in quite slow in real time, so in order to force a larger batch size to be used for predictions, new logic was added. If it turns out that this doesn't really make a difference with power consumption (based on empirical measurement), the default behavior of Listen.py will be reverted.